### PR TITLE
Fix element-wise comparison for grad_lib_values in write_seq.py

### DIFF
--- a/pypulseq/Sequence/write_seq.py
+++ b/pypulseq/Sequence/write_seq.py
@@ -78,8 +78,8 @@ def write(self, file_name: str) -> None:
         output_file.write('\n')
 
     grad_lib_values = np.array(list(self.grad_library.type.values()))
-    arb_grad_mask = grad_lib_values == 'g'
-    trap_grad_mask = grad_lib_values == 't'
+    arb_grad_mask = [value == 'g' for value in grad_lib_values]     # Updated code
+    trap_grad_mask = [value == 't' for value in grad_lib_values]    # Updated code
 
     if any(arb_grad_mask):
         output_file.write('# Format of arbitrary gradients:\n')


### PR DESCRIPTION
### Description
This pull request fixes an issue with element-wise comparison in the write_seq.py code.

#### Problem
The original code compares the entire list `grad_lib_values` to the string `'g'`, which results in `False` instead of an element-wise comparison in some cases depending on python or libraries versions. When `if any(arb_grad_mask)` is called, False gives rise an error, while an empty list works properly.

#### Solution
Updated the code to use a list comprehension to perform element-wise comparison:
```python
arb_grad_mask = [value == 'g' for value in grad_lib_values]
trap_grad_mask = [value == 't' for value in grad_lib_values]

```